### PR TITLE
fix: Feature/update cutadapt wrapper (#67)

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -104,7 +104,9 @@ params:
   # also, separate capitalised letter flags are required for adapters in
   # the reverse reads of paired end sequencing:
   # * https://cutadapt.readthedocs.io/en/stable/guide.html#trimming-paired-end-reads
-  cutadapt-se: ""
+  cutadapt-se:
+    adapters: "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC"
+    extra: "-q 20"
   # reasoning behind parameters:
   #   * `--minimum-length 33`:
   #     * kallisto needs non-empty reads in current versions (fixed for future releases:
@@ -115,4 +117,6 @@ params:
   #     false positive adapter matches
   #   * `--minimum-overlap 7`: the cutadapt default minimum overlap of `5` did trimming on the level
   #     of expected adapter matches by chance
-  cutadapt-pe: "-a ACGGATCGATCGATCGATCGAT -g GGATCGATCGATCGATCGAT -A ACGGATCGATCGATCGATCGAT -G GGATCGATCGATCGATCGAT --minimum-length 33 -e 0.005 --overlap 7"
+  cutadapt-pe: 
+    adapters: "-a ACGGATCGATCGATCGATCGAT -g GGATCGATCGATCGATCGAT -A ACGGATCGATCGATCGATCGAT -G GGATCGATCGATCGATCGAT"
+    extra: "--minimum-length 33 -e 0.005 --overlap 7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
 script:
   - source activate snakemake
   # run the workflow
-  - snakemake --use-conda --directory .test || (for f in .test/logs/*; do echo $f; cat $f; done; for f in .test/logs/*/*; do echo $f; cat $f; done; exit 1)
+  - snakemake --cores all --use-conda --directory .test || (for f in .test/logs/*; do echo $f; cat $f; done; for f in .test/logs/*/*; do echo $f; cat $f; done; exit 1)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -113,7 +113,9 @@ params:
   # also, separate capitalised letter flags are required for adapters in
   # the reverse reads of paired end sequencing:
   # * https://cutadapt.readthedocs.io/en/stable/guide.html#trimming-paired-end-reads
-  cutadapt-se: ""
+  cutadapt-se:
+    adapters: "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC"
+    extra: "-q 20"
   # reasoning behind parameters:
   #   * `--minimum-length 33`:
   #     * kallisto needs non-empty reads in current versions (fixed for future releases:
@@ -124,4 +126,6 @@ params:
   #     false positive adapter matches
   #   * `--minimum-overlap 7`: the cutadapt default minimum overlap of `5` did trimming on the level
   #     of expected adapter matches by chance
-  cutadapt-pe: "-a ACGGATCGATCGATCGATCGAT -g GGATCGATCGATCGATCGAT -A ACGGATCGATCGATCGATCGAT -G GGATCGATCGATCGATCGAT --minimum-length 33 -e 0.005 --overlap 7"
+  cutadapt-pe: 
+    adapters: "-a ACGGATCGATCGATCGATCGAT -g GGATCGATCGATCGATCGAT -A ACGGATCGATCGATCGATCGAT -G GGATCGATCGATCGATCGAT"
+    extra: "--minimum-length 33 -e 0.005 --overlap 7"

--- a/workflow/rules/trim.smk
+++ b/workflow/rules/trim.smk
@@ -5,12 +5,14 @@ rule cutadapt_pe:
         fastq1="results/trimmed/{sample}-{unit}.1.fastq.gz",
         fastq2="results/trimmed/{sample}-{unit}.2.fastq.gz",
         qc="results/trimmed/{sample}-{unit}.qc.txt",
+    threads: 8
     params:
-        "{}".format(config["params"]["cutadapt-pe"]),
+        adapters=config["params"]["cutadapt-pe"]["adapters"],
+        extra=config["params"]["cutadapt-pe"]["extra"],
     log:
         "results/logs/cutadapt/{sample}-{unit}.log",
     wrapper:
-        "0.31.1/bio/cutadapt/pe"
+        "v1.22.0/bio/cutadapt/pe"
 
 
 rule cutadapt:
@@ -19,9 +21,11 @@ rule cutadapt:
     output:
         fastq="results/trimmed/{sample}-{unit}.fastq.gz",
         qc="results/trimmed/{sample}-{unit}.qc.txt",
+    threads: 8
     params:
-        "{}".format(config["params"]["cutadapt-se"]),
+        adapters=config["params"]["cutadapt-se"]["adapters"],
+        extra=config["params"]["cutadapt-se"]["extra"],
     log:
         "results/logs/cutadapt/{sample}-{unit}.log",
     wrapper:
-        "0.31.1/bio/cutadapt/se"
+        "v1.22.0/bio/cutadapt/se"

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -166,9 +166,19 @@ properties:
       kallisto:
         type: string
       cutadapt-se:
-        type: string
+        type: object
+        properties:
+          adapters:
+            type: string
+          extra:
+            type: string
       cutadapt-pe:
-        type: string
+        type: object
+        properties:
+          adapters:
+            type: string
+          extra:
+            type: string
     required:
       - kallisto
       - cutadapt-se


### PR DESCRIPTION
I encountered an error in this trimming rule due to 

```
  File "~/mambaforge/envs/snakemake/lib/python3.10/site-packages/snakemake/__init__.py", line 22, in <module>
    from snakemake.target_jobs import parse_target_jobs_cli_args
  File "~/mambaforge/envs/snakemake/lib/python3.10/site-packages/snakemake/target_jobs.py", line 4, in <module>
    from snakemake.common import parse_key_value_arg
  File "~/mambaforge/envs/snakemake/lib/python3.10/site-packages/snakemake/common/__init__.py", line 284, in <module>
    @contextlib.asynccontextmanager
AttributeError: module 'contextlib' has no attribute 'asynccontextmanager'
```

Tried running under Python 3.10 and 3.7, still encountered the same issue, but eventually tracked the rabbit hole down to this.

Updating the wrapper for cutadapt slightly changes the syntax, but no modification to the config.yaml file is needed. Additionally, (optionally) I added multithreading, as cutadapt scales quite well.

---------

Co-authored-by: David Laehnemann <david.laehnemann@hhu.de>