### PR TITLE
bug: enhancement: enforce schema to prevent bug in sleuth init

### DIFF
--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -67,7 +67,9 @@ properties:
               primary_variable:
                 type: string
               base_level:
-                type: ["number", "string"]
+              # BUG if base_level contains integer @seluth-init.R#L46, relevel(ref="string")
+                type: string
+                
             required:
               - full
               - reduced

--- a/workflow/scripts/sleuth-init.R
+++ b/workflow/scripts/sleuth-init.R
@@ -37,6 +37,7 @@ samples_out <- if (!is.null(model[["full"]])) {
     # TODO migrate this to tidyverse
     # Ensure that primary variable factors are sorted such that base_level comes first.
     # This is important for fold changes, effect sizes to have the expected sign.
+    # BUG when base_level is numerical
     samples[, primary_variable] <- relevel(samples[, primary_variable, drop = TRUE], base_level)
 
     samples %>% select(c(sample, all_of(variables)))

--- a/workflow/scripts/sleuth-init.R
+++ b/workflow/scripts/sleuth-init.R
@@ -1,6 +1,6 @@
-log <- file(snakemake@log[[1]], open="wt")
+log <- file(snakemake@log[[1]], open = "wt")
 sink(log)
-sink(log, type="message")
+sink(log, type = "message")
 
 library("sleuth")
 library("tidyverse")
@@ -8,34 +8,36 @@ library("tidyverse")
 model <- snakemake@params[["model"]]
 
 samples <- read_tsv(snakemake@input[["samples"]], na = "", col_names = TRUE) %>%
-            # make everything except the index, sample name and path string a factor
-            mutate_at(  vars(-sample, -path),
-                        list(~factor(.))
-                        )
+    # make everything except the index, sample name and path string a factor
+    mutate_at(
+        vars(-sample, -path),
+        list(~ factor(.))
+    )
 
-if(!is.null(snakemake@params[["exclude"]])) {
+if (!is.null(snakemake@params[["exclude"]])) {
     samples <- samples %>%
-                filter( !sample %in% snakemake@params[["exclude"]] )
+        filter(!sample %in% snakemake@params[["exclude"]])
 }
 
-samples_out <- if(!is.null(model[["full"]])) {
+samples_out <- if (!is.null(model[["full"]])) {
     # retrieve the model formula
     formula <- as.formula(model[["full"]])
     # extract variables from the formula and unnest any nested variables
     variables <- labels(terms(formula)) %>%
-                    strsplit('[:*]') %>%
-                    unlist()
+        strsplit("[:*]") %>%
+        unlist()
     # remove samples with an NA value in any of the columns
     # relevant for sleuth under the current model
+    # TODO : this might be a bug in sleuth
     samples <- samples %>%
-	        drop_na(c(sample, path, all_of(variables)))
+        drop_na(c(sample, path, all_of(variables)))
 
     primary_variable <- model[["primary_variable"]]
     base_level <- model[["base_level"]]
     # TODO migrate this to tidyverse
     # Ensure that primary variable factors are sorted such that base_level comes first.
     # This is important for fold changes, effect sizes to have the expected sign.
-    samples[, primary_variable] <- relevel(samples[, primary_variable, drop=TRUE], base_level)
+    samples[, primary_variable] <- relevel(samples[, primary_variable, drop = TRUE], base_level)
 
     samples %>% select(c(sample, all_of(variables)))
 } else {
@@ -47,18 +49,18 @@ write_rds(samples_out, file = snakemake@output[["designmatrix"]])
 
 # remove all columns which have only NA values
 samples <- samples %>%
-	    select_if(function(col) !all(is.na(col)))
+    select_if(function(col) !all(is.na(col)))
 
 t2g <- read_rds(snakemake@input[["transcript_info"]])
 
-so <- sleuth_prep(  samples,
-                    extra_bootstrap_summary = TRUE,
-                    target_mapping = t2g,
-                    aggregation_column = "ens_gene",
-                    read_bootstrap_tpm = TRUE,
-                    transform_fun_counts = function(x) log2(x + 0.5),
-                    num_cores = snakemake@threads
-                    )
+so <- sleuth_prep(samples,
+    extra_bootstrap_summary = TRUE,
+    target_mapping = t2g,
+    aggregation_column = "ens_gene",
+    read_bootstrap_tpm = TRUE,
+    transform_fun_counts = function(x) log2(x + 0.5),
+    num_cores = snakemake@threads
+)
 
 if ("canonical" %in% colnames(so$target_mapping)) {
     # Sleuth converts all columns to characters. We don't want that for the canonical column.
@@ -67,22 +69,22 @@ if ("canonical" %in% colnames(so$target_mapping)) {
 }
 
 custom_transcripts <- so$obs_raw %>%
-                        # find transcripts not in the target_mapping
-                        filter(!target_id %in% so$target_mapping$target_id) %>%
-                        # make it a succinct list with no repititions
-                        distinct(target_id) %>%
-                        # pull it out into a vector
-                        pull(target_id)
+    # find transcripts not in the target_mapping
+    filter(!target_id %in% so$target_mapping$target_id) %>%
+    # make it a succinct list with no repititions
+    distinct(target_id) %>%
+    # pull it out into a vector
+    pull(target_id)
 
-if(!length(custom_transcripts) == 0) {
+if (!length(custom_transcripts) == 0) {
     so$target_mapping <- so$target_mapping %>%
-                        # add those custom transcripts as rows to the target mapping
-                        add_row(ens_gene = NA, ext_gene = "Custom", target_id = custom_transcripts, canonical = NA)
+        # add those custom transcripts as rows to the target mapping
+        add_row(ens_gene = NA, ext_gene = "Custom", target_id = custom_transcripts, canonical = NA)
 }
 
-if(!is.null(model[["full"]])) {
-    so <- sleuth_fit(so, as.formula(model[["full"]]), 'full')
-    so <- sleuth_fit(so, as.formula(model[["reduced"]]), 'reduced')
+if (!is.null(model[["full"]])) {
+    so <- sleuth_fit(so, as.formula(model[["full"]]), "full")
+    so <- sleuth_fit(so, as.formula(model[["reduced"]]), "reduced")
 }
 
 sleuth_save(so, snakemake@output[["sleuth_object"]])


### PR DESCRIPTION
This could be considered a WIP, as there still is an underlying problem. 

If we want the ability to use numerical values in the `base_level`, they must also be supported in `primary_variable`. I learned the hard way that if you are using a numerical variable in your design formula like `days: 0,1,2,3,4` and also try to specify a base_level as a numerical value, there is a conflict within the `seluth-init.R` script at #L46.

```R
── Attaching packages ──────────────────────────────────────────────────────────────────────────────────────────────────── tidyverse 1.3.2 ──
✔ ggplot2 3.4.0     ✔ purrr   1.0.1
✔ tibble  3.1.8     ✔ dplyr   1.1.0
✔ tidyr   1.3.0     ✔ stringr 1.5.0
✔ readr   2.1.3     ✔ forcats 1.0.0
── Conflicts ─────────────────────────────────────────────────────────────────────────────────────────────────────── tidyverse_conflicts() ──
✖ dplyr::filter() masks stats::filter()
✖ dplyr::lag()    masks stats::lag()
Rows: 12 Columns: 5
── Column specification ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Delimiter: "\t"
chr (3): sample, batch_effect, path
dbl (2): condition, timepoint_days
...


```